### PR TITLE
test: use ESM test files

### DIFF
--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -1,12 +1,15 @@
 import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
 
+const require = createRequire(import.meta.url);
+
 test('should generate UMD bundle correctly', async ({ page }) => {
   const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+    cwd: import.meta.dirname,
+    rsbuildConfig: (await loadConfig({ cwd: import.meta.dirname })).content,
   });
 
   await rsbuild.build();
@@ -20,7 +23,7 @@ test('should generate UMD bundle correctly', async ({ page }) => {
 
   // Node.js env
   writeFileSync(
-    join(__dirname, 'dist/package.json'),
+    join(import.meta.dirname, 'dist/package.json'),
     JSON.stringify({ type: 'commonjs' }),
   );
   const { double } = require('./dist/index.js');

--- a/test/environments/index.test.ts
+++ b/test/environments/index.test.ts
@@ -1,12 +1,15 @@
 import { existsSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
 
+const require = createRequire(import.meta.url);
+
 test('should generate UMD and web bundle correctly', async ({ page }) => {
   const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+    cwd: import.meta.dirname,
+    rsbuildConfig: (await loadConfig({ cwd: import.meta.dirname })).content,
   });
 
   await rsbuild.build();
@@ -19,11 +22,13 @@ test('should generate UMD and web bundle correctly', async ({ page }) => {
   const test = page.locator('#test');
   await expect(test).toHaveText('2');
 
-  expect(existsSync(join(__dirname, 'dist/static/js/index.js'))).toBeTruthy();
+  expect(
+    existsSync(join(import.meta.dirname, 'dist/static/js/index.js')),
+  ).toBeTruthy();
 
   // Node.js env
   writeFileSync(
-    join(__dirname, 'dist/package.json'),
+    join(import.meta.dirname, 'dist/package.json'),
     JSON.stringify({ type: 'commonjs' }),
   );
   const { double } = require('./dist/umd/index.js');

--- a/test/export-array/index.test.ts
+++ b/test/export-array/index.test.ts
@@ -1,14 +1,17 @@
 import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+const require = createRequire(import.meta.url);
 
 test('should generate UMD bundle with default export correctly', async ({
   page,
 }) => {
   const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+    cwd: import.meta.dirname,
+    rsbuildConfig: (await loadConfig({ cwd: import.meta.dirname })).content,
   });
 
   await rsbuild.build();
@@ -21,7 +24,7 @@ test('should generate UMD bundle with default export correctly', async ({
 
   // Node.js env
   writeFileSync(
-    join(__dirname, 'dist/package.json'),
+    join(import.meta.dirname, 'dist/package.json'),
     JSON.stringify({ type: 'commonjs' }),
   );
   const double = require('./dist/index.js');

--- a/test/export/index.test.ts
+++ b/test/export/index.test.ts
@@ -1,14 +1,17 @@
 import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+const require = createRequire(import.meta.url);
 
 test('should generate UMD bundle with default export correctly', async ({
   page,
 }) => {
   const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+    cwd: import.meta.dirname,
+    rsbuildConfig: (await loadConfig({ cwd: import.meta.dirname })).content,
   });
 
   await rsbuild.build();
@@ -21,7 +24,7 @@ test('should generate UMD bundle with default export correctly', async ({
 
   // Node.js env
   writeFileSync(
-    join(__dirname, 'dist/package.json'),
+    join(import.meta.dirname, 'dist/package.json'),
     JSON.stringify({ type: 'commonjs' }),
   );
   const double = require('./dist/index.js');

--- a/test/package.json
+++ b/test/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "commonjs"
-}

--- a/test/split-chunks/index.test.ts
+++ b/test/split-chunks/index.test.ts
@@ -7,15 +7,17 @@ test('should allow to configure split chunks with UMD plugin', async ({
   page,
 }) => {
   const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+    cwd: import.meta.dirname,
+    rsbuildConfig: (await loadConfig({ cwd: import.meta.dirname })).content,
   });
 
   await rsbuild.build();
   const { server, urls } = await rsbuild.preview();
 
-  expect(existsSync(join(__dirname, 'dist/index.js'))).toBeTruthy();
-  expect(existsSync(join(__dirname, 'dist/lib-react.js'))).toBeTruthy();
+  expect(existsSync(join(import.meta.dirname, 'dist/index.js'))).toBeTruthy();
+  expect(
+    existsSync(join(import.meta.dirname, 'dist/lib-react.js')),
+  ).toBeTruthy();
 
   // Browser env
   await page.goto(urls[0]);


### PR DESCRIPTION
## Summary

This PR updates the Playwright tests to run with standard ESM semantics instead of relying on a `test/package.json` CommonJS scope. The tests now use `import.meta.dirname` for fixture paths and `createRequire(import.meta.url)` only where they need to verify the CommonJS UMD output, so Rsbuild config files are loaded under the repository's normal module scope.

## Related Links

https://github.com/rstackjs/rsbuild-plugin-umd/pull/63