### PR TITLE
chore(deps): upgrade Rslint to v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "^2.1.6",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "^0.23.2",
-    "@rslint/core": "^0.7.0",
+    "@rslint/core": "^0.8.0",
     "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.2",
     "@rstest/playwright": "^0.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.23.2
         version: 0.23.2(typescript@7.0.2)
       '@rslint/core':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       '@rstackjs/test-utils':
         specifier: ^0.2.0
         version: 0.2.0
@@ -177,56 +177,56 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.7.0':
-    resolution: {integrity: sha512-IqpKezDIo5RI0oimj24OmtfhgbV86Af9L0QOy3HWAjdCO2cD+UxU/zjY7jZjfoL/xE2d2Y8rMuUS1hKxX/XB4g==}
+  '@rslint/core@0.8.0':
+    resolution: {integrity: sha512-MfMC6lxiXoKPWsYRu9fuAxWA9mCD/I4E5Aa6Sl20a6q5w8r2C12fJM+bceC01AMGYuvWygKHqS3QBJdJHjniRw==}
     hasBin: true
     peerDependencies:
-      jiti: ^2.0.0
+      jiti: ^2.7.0
     peerDependenciesMeta:
       jiti:
         optional: true
 
-  '@rslint/native-darwin-arm64@0.7.0':
-    resolution: {integrity: sha512-GFBQfKq4HIF41HlPvUEvqgUxi6AhVDpA9AaGktT8DUCLHwaMf+iV3SxqNElenXB78JlsNZHAP0N34f26aLn62w==}
+  '@rslint/native-darwin-arm64@0.8.0':
+    resolution: {integrity: sha512-Bo6kXL1/TkjVUl6maZ3Sw+JEnZUkgpUD35v06jyBTcjpxlXE6yqFj66NAzB/G2CVu220ADp/FEE7l2Kocrefhg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/native-darwin-x64@0.7.0':
-    resolution: {integrity: sha512-K9bKLC1XdqM3EMJYXoxuBl/pJId16nKR+5Cz8Xovt84j/DBk8GkWr0BfiutJD7RQVMRnL0q0Za7SmTrMjwteCw==}
+  '@rslint/native-darwin-x64@0.8.0':
+    resolution: {integrity: sha512-F5pabdH7dluxoj7PGuQjPYuoNU+yxnctcJzqrb/CZ122FLP3uJPrbiLufh+ZF9e5ui700rNyb7macJqnHlBV2w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/native-linux-arm64-gnu@0.7.0':
-    resolution: {integrity: sha512-w+kle2awJrWozQFJlbno46ZpSC6DuIvkCv2PIBKRTtfX+EgPJyuYqG2FohVyz+ErjlyeJxf9HulCvliQGZpBVg==}
+  '@rslint/native-linux-arm64-gnu@0.8.0':
+    resolution: {integrity: sha512-SSgSjyaeXI032Wk8bq6VmkLQTWOEqHZH5MWAk3831pd/G2rWr2XcoDi5Wf6w0o2rSCeYzkYbIejOePYwIKT4Lg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-arm64-musl@0.7.0':
-    resolution: {integrity: sha512-CeAj1GYTGzrDTzQPhAyIc4S1AZopmJUnVWgK+RIt5OlNA7RcjQP0tFy2gymiTlM8mLrzoDgyWh7zXTKCdsfRuA==}
+  '@rslint/native-linux-arm64-musl@0.8.0':
+    resolution: {integrity: sha512-50VDZQFAc9kp6rbOUOjyppVjC3d3AdbOJyA6JxlhK3mp8a/8sPIqWG0BlfcN/7ZpwdZrFsQt2Ds+0yMXITfu5A==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-linux-x64-gnu@0.7.0':
-    resolution: {integrity: sha512-PUnVgXdd9znoNe7I8r0mbmaFGFoWzDicMZZCbAiJl+o+Z3fG6EsJBJj2z7GzBeQll8ebt+VXmuGbGSOW+S0C6Q==}
+  '@rslint/native-linux-x64-gnu@0.8.0':
+    resolution: {integrity: sha512-wfc/UfnuTBAofwLPK5MLB2Hus1YYnsxP2MVchp380fUvMfQuGFPzz1WOAUY66zqrsrDKpUJsh3V1bx7c8DTlJA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-x64-musl@0.7.0':
-    resolution: {integrity: sha512-sabOOEO8sHTdaR3emZHyF7oYfwoeBk+turTxE1OZ4eXrApQCWakVmI1B6a1tWNsJuESFkZQtpZJHmRPjNnhn2g==}
+  '@rslint/native-linux-x64-musl@0.8.0':
+    resolution: {integrity: sha512-MTYcAMz6IZWb6ZmLo12pakCBA8mS3EW9cOI0jd3At6vs0Yia9YbeOAUiWbIC4Z9yyp75b8ZQCQMRSnY6rDnbaA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-win32-arm64-msvc@0.7.0':
-    resolution: {integrity: sha512-G21YrMqbvotuzAtMWMjxPnFDfwzxN38KEcOyb4URU8x1/GbA866bqI4OlF3+GZkgNsy84XseRYMJvT9T+OpTEg==}
+  '@rslint/native-win32-arm64-msvc@0.8.0':
+    resolution: {integrity: sha512-hids2jgNWBxZf2mSBLZJxubWRLWlJapEfeJHVokzjpRpBZZNv7O06enoyXSb4Lswff9WaHssIqu1sfZIc9lC2g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/native-win32-x64-msvc@0.7.0':
-    resolution: {integrity: sha512-3tgUASBRarhu2Es0kyiUUs+VBs2LqBfisS2A1e4E9pSrAsy/gjr0zokEfCxIqjMP6L52jei4jl1C1IWfupwGQQ==}
+  '@rslint/native-win32-x64-msvc@0.8.0':
+    resolution: {integrity: sha512-bun7uURKl6NdChwmw/i2mk3Yj9klZQyh1uRbIQG0RDEJ9oTIbU5M3c7K5sd/Rukat0TVCGgbBAzR+YB0DAXPZQ==}
     cpu: [x64]
     os: [win32]
 
@@ -566,8 +566,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   playwright-core@1.61.1:
@@ -748,41 +748,41 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslint/core@0.7.0':
+  '@rslint/core@0.8.0':
     dependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
-      '@rslint/native-darwin-arm64': 0.7.0
-      '@rslint/native-darwin-x64': 0.7.0
-      '@rslint/native-linux-arm64-gnu': 0.7.0
-      '@rslint/native-linux-arm64-musl': 0.7.0
-      '@rslint/native-linux-x64-gnu': 0.7.0
-      '@rslint/native-linux-x64-musl': 0.7.0
-      '@rslint/native-win32-arm64-msvc': 0.7.0
-      '@rslint/native-win32-x64-msvc': 0.7.0
+      '@rslint/native-darwin-arm64': 0.8.0
+      '@rslint/native-darwin-x64': 0.8.0
+      '@rslint/native-linux-arm64-gnu': 0.8.0
+      '@rslint/native-linux-arm64-musl': 0.8.0
+      '@rslint/native-linux-x64-gnu': 0.8.0
+      '@rslint/native-linux-x64-musl': 0.8.0
+      '@rslint/native-win32-arm64-msvc': 0.8.0
+      '@rslint/native-win32-x64-msvc': 0.8.0
 
-  '@rslint/native-darwin-arm64@0.7.0':
+  '@rslint/native-darwin-arm64@0.8.0':
     optional: true
 
-  '@rslint/native-darwin-x64@0.7.0':
+  '@rslint/native-darwin-x64@0.8.0':
     optional: true
 
-  '@rslint/native-linux-arm64-gnu@0.7.0':
+  '@rslint/native-linux-arm64-gnu@0.8.0':
     optional: true
 
-  '@rslint/native-linux-arm64-musl@0.7.0':
+  '@rslint/native-linux-arm64-musl@0.8.0':
     optional: true
 
-  '@rslint/native-linux-x64-gnu@0.7.0':
+  '@rslint/native-linux-x64-gnu@0.8.0':
     optional: true
 
-  '@rslint/native-linux-x64-musl@0.7.0':
+  '@rslint/native-linux-x64-musl@0.8.0':
     optional: true
 
-  '@rslint/native-win32-arm64-msvc@0.7.0':
+  '@rslint/native-win32-arm64-msvc@0.8.0':
     optional: true
 
-  '@rslint/native-win32-x64-msvc@0.7.0':
+  '@rslint/native-win32-x64-msvc@0.8.0':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.1.3':
@@ -1013,7 +1013,7 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   playwright-core@1.61.1: {}
 

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig, ts } from '@rslint/core';
+import { defineConfig, js, ts } from '@rslint/core';
 
 export default defineConfig([
+  js.configs.recommended,
   ts.configs.recommended,
   {
     files: ['test/**/*.ts'],

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
     NODE_ENV: undefined,
   },
   isolate: false,
+  testTimeout: 15_000,
 });


### PR DESCRIPTION
## Summary

- Upgrade `@rslint/core` to v0.8.0 and refresh the lockfile where applicable.
- Preserve the existing recommended-rule coverage under Rslint 0.8.
- Resolve newly surfaced lint diagnostics where needed.
- Verify the relevant lint checks pass.

## Related Links

- https://github.com/web-infra-dev/rslint/releases/tag/v0.8.0